### PR TITLE
Fix server error caused by missing resource

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.rst
 include LICENSE
 include requirements.txt
-recursive-include ckanext/kpis *.html *.json *.js *.less *.css *.mo  *.po *.pot *.png *.jpg
+recursive-include ckanext/kpis *.html *.json *.js *.less *.css *.mo  *.po *.pot *.png *.jpg *.config

--- a/ckanext/kpis/controller.py
+++ b/ckanext/kpis/controller.py
@@ -5,11 +5,15 @@ from ckan.lib.base import BaseController
 import stats as stats_lib
 import ckan.lib.helpers as h
 
+from ckanext.kpis.plugin import show_graphs
+
 
 class StatsController(BaseController):
 
     def index(self):
         c = p.toolkit.c
+
+        c.show_graphs = show_graphs
 
         usage_stats = stats_lib.UsageStats()
         c.num_api_calls_by_week = usage_stats.get_hit_counts('api')

--- a/ckanext/kpis/plugin.py
+++ b/ckanext/kpis/plugin.py
@@ -4,6 +4,7 @@ from logging import getLogger
 
 import ckan.plugins as p
 import ckan.config.middleware.common_middleware as middleware
+from ckan.common import config
 
 import sqlalchemy as sa
 import hashlib
@@ -92,3 +93,5 @@ class TrackingPlusMiddleware(object):
         return self.app(environ, start_response)
 
 middleware.TrackingMiddleware = TrackingPlusMiddleware
+
+show_graphs = p.toolkit.asbool(config.get('ckanext.kpis.show_graphs', False))

--- a/ckanext/kpis/public/ckanext/kpis/resource.config
+++ b/ckanext/kpis/public/ckanext/kpis/resource.config
@@ -4,9 +4,15 @@ lte IE 8 = vendor/excanvas.js
 
 [groups]
 
-kpis =
+with-graphs =
     css/stats.css
     vendor/excanvas.js
     vendor/jquery.flot.js
     javascript/modules/plot.js
+    javascript/modules/stats-nav.js
+
+without-graphs =
+    css/stats.css
+    vendor/excanvas.js
+    vendor/jquery.flot.js
     javascript/modules/stats-nav.js

--- a/ckanext/kpis/templates/ckanext/kpis/index.html
+++ b/ckanext/kpis/templates/ckanext/kpis/index.html
@@ -213,5 +213,9 @@
 
 {% block scripts %}
   {{ super() }}
-  {% resource "ckanext-kpis/kpis" %}
+  {% if c.show_graphs %}
+    {% resource "ckanext-kpis/with-graphs" %}
+  {% else %}
+    {% resource "ckanext-kpis/without-graphs" %}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
(Tested on staging)

The extension bundles several bits of JavaScript and CSS into a resource for displaying graphs. The resource is defined by a .config file. Since the manifest didn't include .config files, there was no definition of the resource available when deployed to a server. This resulted in a server error when attempting to render the template and include the resource. Including the resource config file in the manifest fixes the problem.