### PR TITLE
Set KPI goals, show completion percentages, and calculate monthly KPIs

### DIFF
--- a/ckanext/kpis/controller.py
+++ b/ckanext/kpis/controller.py
@@ -26,6 +26,11 @@ class StatsController(BaseController):
         c.num_organizations_by_week = usage_stats.get_organization_counts()
 
 
+        c.num_users_by_month = [{'date': h.date_str_to_datetime(month_date),\
+            'users': users, 'percent_complete': percentage} for month_date,\
+            users, percentage in usage_stats.get_monthly_user_counts('all')]
+
+
         c.raw_packages_by_week = [{'date': h.date_str_to_datetime(week_date),\
             'total_packages': cumulative_num_hits, \
             'percent_complete': percentage} for week_date,\

--- a/ckanext/kpis/controller.py
+++ b/ckanext/kpis/controller.py
@@ -5,11 +5,15 @@ from ckan.lib.base import BaseController
 import stats as stats_lib
 import ckan.lib.helpers as h
 
+from ckanext.kpis.plugin import kpi_goals
+
 
 class StatsController(BaseController):
 
     def index(self):
         c = p.toolkit.c
+
+        c.kpi_goals = kpi_goals
 
         usage_stats = stats_lib.UsageStats()
         c.num_api_calls_by_week = usage_stats.get_hit_counts('api')
@@ -23,8 +27,9 @@ class StatsController(BaseController):
 
 
         c.raw_packages_by_week = [{'date': h.date_str_to_datetime(week_date),\
-            'total_packages': cumulative_num_hits} for week_date,\
-            cumulative_num_hits in c.num_datasets_by_week]
+            'total_packages': cumulative_num_hits, \
+            'percent_complete': percentage} for week_date,\
+            cumulative_num_hits, percentage in c.num_datasets_by_week]
 
         c.raw_resources_by_week = [{'date': h.date_str_to_datetime(week_date),\
             'total_resources': cumulative_num_hits} for week_date,\
@@ -35,8 +40,9 @@ class StatsController(BaseController):
             cumulative_num_hits in c.num_organizations_by_week]
 
         c.raw_harvesters_by_week = [{'date': h.date_str_to_datetime(week_date),\
-            'total_packages': cumulative_num_hits} for week_date,\
-            cumulative_num_hits in c.num_harvesters_by_week]
+            'total_packages': sources, \
+            'percent_complete': percentage} for week_date,\
+            sources, percentage in c.num_harvesters_by_week]
 
         c.raw_api_calls_by_week = [{'date': h.date_str_to_datetime(week_date),\
             'total_hits': cumulative_num_hits} for week_date,\

--- a/ckanext/kpis/helpers.py
+++ b/ckanext/kpis/helpers.py
@@ -1,0 +1,48 @@
+import json
+
+from ckan.common import config
+
+
+def get_goals():
+    """
+    Return a dictionary with the KPI goals.
+    If no goals are defined in the config, return a dictionary with 
+    placeholder values. If the goals are defined in an invalid way, 
+    raise an exception.
+    """
+    default_goals = {
+        'total_datasets': 10000000,
+        'total_sources': 20,
+        'monthly_users': 2000
+    }
+
+    valid_goals = [
+        'total_datasets',
+        'total_sources',
+        'monthly_users',
+    ]
+
+    goals_json = config.get('ckanext.kpis.goals')
+
+    if not goals_json:
+        return default_goals
+
+    goals = json.loads(goals_json)
+
+    # Make sure the goals are valid
+    invalid_goals = []
+    for i in goals:
+        if i not in valid_goals:
+            invalid_goals.append(i)
+    if invalid_goals:
+        raise ValueError('Invalid KPI goals: {}'.format(invalid_goals))
+
+    # Make sure the goals have valid values
+    invalid_values = []
+    for i in goals:
+        if not isinstance(goals[i], int):
+            invalid_values.append({i: goals[i]})
+    if invalid_values:
+        raise ValueError('Invalid KPI values: {}'.format(invalid_values))
+
+    return goals

--- a/ckanext/kpis/plugin.py
+++ b/ckanext/kpis/plugin.py
@@ -1,15 +1,18 @@
 # encoding: utf-8
 
 from logging import getLogger
-
-import ckan.plugins as p
-import ckan.config.middleware.common_middleware as middleware
-
 import sqlalchemy as sa
 import hashlib
 import urllib2
 
+import ckan.plugins as p
+import ckan.config.middleware.common_middleware as middleware
+
+from ckanext.kpis import helpers
+
+
 log = getLogger(__name__)
+
 
 class KPIsPlugin(p.SingletonPlugin):
     """KPIs plugin"""
@@ -92,3 +95,5 @@ class TrackingPlusMiddleware(object):
         return self.app(environ, start_response)
 
 middleware.TrackingMiddleware = TrackingPlusMiddleware
+
+kpi_goals = helpers.get_goals()

--- a/ckanext/kpis/stats.py
+++ b/ckanext/kpis/stats.py
@@ -42,7 +42,6 @@ class UsageStats(object):
 
     @classmethod
     def get_weeks(cls):
-        #first_date = get_first_date()
         today = datetime.datetime.utcnow().date()
         week_start = first_date - datetime.timedelta(days=datetime.date.weekday(first_date))
         weeks = []
@@ -61,18 +60,6 @@ class UsageStats(object):
             days.append(day_one + datetime.timedelta(days=i))
         days.append(week[1])
         return days
-
-    # @classmethod
-    # def get_hits_for_week(cls, week):
-    #     tracking_raw = table('tracking_raw')
-    #     s = select([func.count(tracking_raw.c.access_timestamp)], from_obj=[tracking_raw]).\
-    #           where(and_(tracking_raw.c.access_timestamp >= week[0], tracking_raw.c.access_timestamp <= week[1]))
-    #     count = model.Session.execute(s).fetchone()[0]
-    #     #session.query(func.count(tracking_type.c.access_timestamp))
-    #     #select([func.count()]).select_from(tracking_raw).filter(and_(tracking_raw.access_timestamp >= week[0]).\
-    #     #    filter(tracking_raw <= week[1]))
-    #     return count
-
 
     @classmethod
     def get_hit_counts(cls, tracking_type):

--- a/ckanext/kpis/stats.py
+++ b/ckanext/kpis/stats.py
@@ -1,18 +1,12 @@
 # encoding: utf-8
 
 import datetime
-
-from ckan.common import config
 from sqlalchemy import Table, select, join, func, and_, distinct
 
+from ckan.common import config
 import ckan.plugins as p
 import ckan.model as model
 
-cache_enabled = p.toolkit.asbool(config.get('ckanext.kpis.cache_enabled', 'False'))
-
-if cache_enabled:
-    from pylons import cache
-    our_cache = cache.get_cache('stats', type='dbm')
 
 DATE_FORMAT = '%Y-%m-%d'
 

--- a/ckanext/kpis/stats.py
+++ b/ckanext/kpis/stats.py
@@ -7,6 +7,8 @@ from ckan.common import config
 import ckan.plugins as p
 import ckan.model as model
 
+from ckanext.kpis.plugin import kpi_goals
+
 
 DATE_FORMAT = '%Y-%m-%d'
 
@@ -30,6 +32,11 @@ def get_first_date():
     return first_date
 
 first_date = get_first_date()
+
+
+def calc_percentage(goal, value):
+    """Return the percentage of the goal completed."""
+    return round(100 * (float(value) / float(goal)), 2)
 
 
 class UsageStats(object):
@@ -109,13 +116,24 @@ class UsageStats(object):
 
     @classmethod
     def get_dataset_counts_for_weeks(cls, set_type, weeks):
+        """Returns a list of the total number of datasets or harvesters,
+        depending on the set_type, plus the completion percentage for
+        the respective KPI goal for each week in weeks.
+        """
         dataset_counts_for_weeks = []
         count = 0
+        # Determine the correct goal
+        if set_type == 'dataset':
+            goal = kpi_goals['total_datasets']
+        elif set_type == 'harvest':
+            goal = kpi_goals['total_sources']
         for week in weeks:
             count += cls.get_datasets_for_week(set_type, week)
+            percent = calc_percentage(goal, count)
             dataset_counts_for_weeks.append((week[0].strftime(DATE_FORMAT),
-                count))
+                count, percent))
         return dataset_counts_for_weeks
+
 
     @classmethod
     def get_resource_counts_for_weeks(cls, weeks):

--- a/ckanext/kpis/templates/ckanext/kpis/index.html
+++ b/ckanext/kpis/templates/ckanext/kpis/index.html
@@ -5,7 +5,11 @@
 {% endblock %}
 
 {% set datasets_heading = '{} ({}% {})'.format(_('Total Datasets'), c.raw_packages_by_week[-1]['percent_complete'], _('complete')) %}
+
 {% set sources_heading = '{} ({}% {})'.format(_('Total Sources'), c.raw_harvesters_by_week[-1]['percent_complete'], _('complete')) %}
+
+{% set users_heading = '{} ({}% {})'.format(_('Monthly Users'), c.num_users_by_month[-1]['percent_complete'], _('complete')) %}
+
 
 {% block primary_content %}
   <article class="module">
@@ -156,6 +160,34 @@
       </table>
     </section>
 
+    <section id="stats-total-monthly-users" class="module-content tab-content">
+      <h2>{{ users_heading }}</h2>
+      <p>{{ _('Goal:') }} {{ c.kpi_goals['monthly_users'] }}</br>
+      {{ _('Current total:') }} {{ c.num_users_by_month[-1]['users'] }}</br>
+      {{ _('Percentatge complete:') }} {{ c.num_users_by_month[-1]['percent_complete'] }}%</p>
+
+      {% set xaxis = {'mode': 'time', 'timeformat': '%y-%b'} %}
+      {% set yaxis = {'min': 0} %}
+      <table class="table table-chunky table-bordered table-striped" data-module="plot" data-module-xaxis="{{ h.dump_json(xaxis) }}" data-module-yaxis="{{ h.dump_json(yaxis) }}">
+        <thead>
+          <tr>
+            <th>{{ _('Month') }}</th>
+            <th>{{ _('Users in Month') }}</th>
+            <th>{{ _('Percentage Completed') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in c.num_users_by_month %}
+            <tr>
+              <th data-type="date" data-value="{{ row.date.strftime("%s") }}"><time datetime="{{ row.date.isoformat() }}">{{ h.render_datetime(row.date, '%B %Y') }}</time></th>
+              <td>{{ row.users }}</td>
+              <td>{{ row.percent_complete }}%</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+
     <section id="stats-total-api-visits" class="module-content tab-content">
       <h2>{{ _('Daily API Users (Weekly)') }}</h2>
 
@@ -218,6 +250,7 @@
         <li class="nav-item"><a href="#stats-total-hits" data-toggle="tab">{{ _('Website Hits (Weekly)') }}</a></li>
         <li class="nav-item"><a href="#stats-total-api-visits" data-toggle="tab">{{ _('Daily API Users (Weekly)') }}</a></li>
         <li class="nav-item"><a href="#stats-total-page-visits" data-toggle="tab">{{ _('Daily Website Users (Weekly)') }}</a></li>
+        <li class="nav-item"><a href="#stats-total-monthly-users" data-toggle="tab">{{ users_heading }}</a></li>
       </ul>
     </nav>
   </section>

--- a/ckanext/kpis/templates/ckanext/kpis/index.html
+++ b/ckanext/kpis/templates/ckanext/kpis/index.html
@@ -13,6 +13,7 @@
 
 {% block primary_content %}
   <article class="module">
+    {% if c.kpi_goals['total_datasets'] %}
     <section id="stats-total-datasets" class="module-content tab-content active">
       <h2>{{ datasets_heading }}</h2>
       <p>{{ _('Goal:') }} {{ c.kpi_goals['total_datasets'] }}</br>
@@ -40,7 +41,9 @@
         </tbody>
       </table>
     </section>
+    {% endif %}
 
+    {% if c.kpi_goals['total_resources'] %}
     <section id="stats-total-resources" class="module-content tab-content">
       <h2>{{ _('Total Resources (Weekly)') }}</h2>
 
@@ -63,7 +66,9 @@
         </tbody>
       </table>
     </section>
+    {% endif %}
 
+    {% if c.kpi_goals['total_sources'] %}
     <section id="stats-total-sources" class="module-content tab-content">
       <h2>{{ sources_heading }}</h2>
       <p>{{ _('Goal:') }} {{ c.kpi_goals['total_sources'] }}</br>
@@ -90,7 +95,9 @@
         </tbody>
       </table>
     </section>
+    {% endif %}
 
+    {% if c.kpi_goals['total_providers'] %}
     <section id="stats-total-providers" class="module-content tab-content">
       <h2>{{ _('Total Providers (Weekly)') }}</h2>
 
@@ -113,7 +120,9 @@
         </tbody>
       </table>
     </section>
+    {% endif %}
 
+    {% if c.kpi_goals['total_api_calls'] %}
     <section id="stats-total-api-calls" class="module-content tab-content">
       <h2>{{ _('API Calls per Week') }}</h2>
 
@@ -136,7 +145,9 @@
         </tbody>
       </table>
     </section>
+    {% endif %}
 
+    {% if c.kpi_goals['total_hits'] %}
     <section id="stats-total-hits" class="module-content tab-content">
       <h2>{{ _('Website Hits (Weekly)') }}</h2>
 
@@ -159,7 +170,9 @@
         </tbody>
       </table>
     </section>
+    {% endif %}
 
+    {% if c.kpi_goals['monthly_users'] %}
     <section id="stats-total-monthly-users" class="module-content tab-content">
       <h2>{{ users_heading }}</h2>
       <p>{{ _('Goal:') }} {{ c.kpi_goals['monthly_users'] }}</br>
@@ -187,7 +200,9 @@
         </tbody>
       </table>
     </section>
+    {% endif %}
 
+    {% if c.kpi_goals['total_api_visits'] %}
     <section id="stats-total-api-visits" class="module-content tab-content">
       <h2>{{ _('Daily API Users (Weekly)') }}</h2>
 
@@ -210,7 +225,9 @@
         </tbody>
       </table>
     </section>
+    {% endif %}
 
+    {% if c.kpi_goals['total_page_visits'] %}
     <section id="stats-total-page-visits" class="module-content tab-content">
       <h2>{{ _('Daily Website Users (Weekly)') }}</h2>
 
@@ -233,6 +250,7 @@
         </tbody>
       </table>
     </section>
+    {% endif %}
 
   </article>
 {% endblock %}
@@ -242,15 +260,33 @@
     <h2 class="module-heading"><i class="icon-bar-chart icon-medium"></i> {{ _('KPI Menu') }}</h2>
     <nav data-module="stats-nav">
       <ul class="unstyled nav nav-simple">
+        {% if c.kpi_goals['total_datasets'] %}
         <li class="nav-item active"><a href="#stats-total-datasets" data-toggle="tab">{{ datasets_heading }}</a></li>
+        {% endif %}
+        {% if c.kpi_goals['total_resources'] %}
         <li class="nav-item"><a href="#stats-total-resources" data-toggle="tab">{{ _('Total Resources (Weekly)') }}</a></li>
+        {% endif %}        
+        {% if c.kpi_goals['total_sources'] %}
         <li class="nav-item"><a href="#stats-total-sources" data-toggle="tab">{{ sources_heading }}</a></li>
+        {% endif %}        
+        {% if c.kpi_goals['total_providers'] %}        
         <li class="nav-item"><a href="#stats-total-providers" data-toggle="tab">{{ _('Total Providers (Weekly)') }}</a></li>
+        {% endif %}
+        {% if c.kpi_goals['total_api_calls'] %}
         <li class="nav-item"><a href="#stats-total-api-calls" data-toggle="tab">{{ _('API Calls (Weekly)') }}</a></li>
+        {% endif %}        
+        {% if c.kpi_goals['total_hits'] %}        
         <li class="nav-item"><a href="#stats-total-hits" data-toggle="tab">{{ _('Website Hits (Weekly)') }}</a></li>
+        {% endif %}        
+        {% if c.kpi_goals['total_api_visits'] %}        
         <li class="nav-item"><a href="#stats-total-api-visits" data-toggle="tab">{{ _('Daily API Users (Weekly)') }}</a></li>
+        {% endif %}
+        {% if c.kpi_goals['total_page_visits'] %}        
         <li class="nav-item"><a href="#stats-total-page-visits" data-toggle="tab">{{ _('Daily Website Users (Weekly)') }}</a></li>
+        {% endif %}
+        {% if c.kpi_goals['monthly_users'] %}        
         <li class="nav-item"><a href="#stats-total-monthly-users" data-toggle="tab">{{ users_heading }}</a></li>
+        {% endif %}
       </ul>
     </nav>
   </section>

--- a/ckanext/kpis/templates/ckanext/kpis/index.html
+++ b/ckanext/kpis/templates/ckanext/kpis/index.html
@@ -4,18 +4,25 @@
   <li class="active">{{ _('KPIs') }}</li>
 {% endblock %}
 
+{% set datasets_heading = '{} ({}% {})'.format(_('Total Datasets'), c.raw_packages_by_week[-1]['percent_complete'], _('complete')) %}
+{% set sources_heading = '{} ({}% {})'.format(_('Total Sources'), c.raw_harvesters_by_week[-1]['percent_complete'], _('complete')) %}
+
 {% block primary_content %}
   <article class="module">
     <section id="stats-total-datasets" class="module-content tab-content active">
-      <h2>{{ _('Total Datasets (Weekly)') }}</h2>
+      <h2>{{ datasets_heading }}</h2>
+      <p>{{ _('Goal:') }} {{ c.kpi_goals['total_datasets'] }}</br>
+      {{ _('Current total:') }} {{ c.raw_packages_by_week[-1]['total_packages'] }}</br>
+      {{ _('Percentatge complete:') }} {{ c.raw_packages_by_week[-1]['percent_complete'] }}%</p>
 
       {% set xaxis = {'mode': 'time', 'timeformat': '%y-%b'} %}
       {% set yaxis = {'min': 0} %}
       <table class="table table-chunky table-bordered table-striped" data-module="plot" data-module-xaxis="{{ h.dump_json(xaxis) }}" data-module-yaxis="{{ h.dump_json(yaxis) }}">
         <thead>
           <tr>
-            <th>{{ _("Week") }}</th>
-            <th>{{ _("Total Datasets") }}</th>
+            <th>{{ _('Week') }}</th>
+            <th>{{ _('Total Datasets') }}</th>
+            <th>{{ _('Percentage Completed') }}</th>
           </tr>
         </thead>
         <tbody>
@@ -23,6 +30,7 @@
             <tr>
               <th data-type="date" data-value="{{ row.date.strftime("%s") }}"><time datetime="{{ row.date.isoformat() }}">{{ h.render_datetime(row.date) }}</time></th>
               <td>{{ row.total_packages }}</td>
+              <td>{{ row.percent_complete }}%</td>
             </tr>
           {% endfor %}
         </tbody>
@@ -53,15 +61,18 @@
     </section>
 
     <section id="stats-total-sources" class="module-content tab-content">
-      <h2>{{ _('Total Sources (Weekly)') }}</h2>
-
+      <h2>{{ sources_heading }}</h2>
+      <p>{{ _('Goal:') }} {{ c.kpi_goals['total_sources'] }}</br>
+      {{ _('Current total:') }} {{ c.raw_harvesters_by_week[-1]['total_packages'] }}</br>
+      {{ _('Percentatge complete:') }} {{ c.raw_harvesters_by_week[-1]['percent_complete'] }}%</p>
       {% set xaxis = {'mode': 'time', 'timeformat': '%y-%b'} %}
       {% set yaxis = {'min': 0} %}
       <table class="table table-chunky table-bordered table-striped" data-module="plot" data-module-xaxis="{{ h.dump_json(xaxis) }}" data-module-yaxis="{{ h.dump_json(yaxis) }}">
         <thead>
           <tr>
-            <th>{{ _("Week") }}</th>
-            <th>{{ _("Total Sources") }}</th>
+            <th>{{ _('Week') }}</th>
+            <th>{{ _('Total Sources') }}</th>
+            <th>{{ _('Percentage Completed') }}</th>
           </tr>
         </thead>
         <tbody>
@@ -69,6 +80,7 @@
             <tr>
               <th data-type="date" data-value="{{ row.date.strftime("%s") }}"><time datetime="{{ row.date.isoformat() }}">{{ h.render_datetime(row.date) }}</time></th>
               <td>{{ row.total_packages }}</td>
+              <td>{{ row.percent_complete }}</td>
             </tr>
           {% endfor %}
         </tbody>
@@ -198,9 +210,9 @@
     <h2 class="module-heading"><i class="icon-bar-chart icon-medium"></i> {{ _('KPI Menu') }}</h2>
     <nav data-module="stats-nav">
       <ul class="unstyled nav nav-simple">
-        <li class="nav-item active"><a href="#stats-total-datasets" data-toggle="tab">{{ _('Total Datasets (Weekly)') }}</a></li>
+        <li class="nav-item active"><a href="#stats-total-datasets" data-toggle="tab">{{ datasets_heading }}</a></li>
         <li class="nav-item"><a href="#stats-total-resources" data-toggle="tab">{{ _('Total Resources (Weekly)') }}</a></li>
-        <li class="nav-item"><a href="#stats-total-sources" data-toggle="tab">{{ _('Total Sources (Weekly)') }}</a></li>
+        <li class="nav-item"><a href="#stats-total-sources" data-toggle="tab">{{ sources_heading }}</a></li>
         <li class="nav-item"><a href="#stats-total-providers" data-toggle="tab">{{ _('Total Providers (Weekly)') }}</a></li>
         <li class="nav-item"><a href="#stats-total-api-calls" data-toggle="tab">{{ _('API Calls (Weekly)') }}</a></li>
         <li class="nav-item"><a href="#stats-total-hits" data-toggle="tab">{{ _('Website Hits (Weekly)') }}</a></li>


### PR DESCRIPTION
This pull request adds three related features that we need for the project:
1. Set goals for each KPI as a site setting
2. Display completion percentages for each KPI
3. Calculate monthly users, rather than weekly or daily users

It also makes the KPIs displayed on the portal conditional on what goals have been set. This is a temporary fix to avoid showing KPIs that haven't been requested, which could cause confusion. (In a future version the KPIs should be generated and displayed dynamically—on the front end we can replace all the individual tables with a table snippet, for instance—but that requires more work that isn't necessary just yet.)

The graphs are another area that will need work, since the current behavior is to include each column, meaning that both the total and the percentage appear on the graph. The graphs also default to weekly intervals even for monthly KPIs. Pull request [#1] makes it possible to configure whether the graphs are displayed. Since the graphs aren't strictly required (just the stats), we can deploy with the graphs disabled for now.
