### PR TITLE
[#3] Use 1st revision date if start date isn't set

### DIFF
--- a/ckanext/kpis/stats.py
+++ b/ckanext/kpis/stats.py
@@ -22,14 +22,20 @@ def datetime2date(datetime_):
     return datetime.date(datetime_.year, datetime_.month, datetime_.day)
 
 def get_first_date():
-    first_date = config.get('ckanext.kpis.first_date')
-    if not first_date:
-        tracking_raw = table('tracking_raw')
-        s = select([func.min(tracking_raw.c.access_timestamp)],\
-            from_obj=[tracking_raw])
+    """Return the starting date for calculating all the KPIs.
+    If the date isn't specified in the config, then the earliest revision
+    date is used instead.
+
+    The format of the date in the config must be `YYYY/mm/dd`.
+    """
+    config_date = config.get('ckanext.kpis.first_date')
+    if not config_date:
+        revision = table('revision')
+        s = select([func.min(revision.c.timestamp)],\
+            from_obj=[revision])
         first_date = model.Session.execute(s).fetchone()[0].date()
     else:
-        first_date = datetime.datetime.strptime('01/Jun/2017', '%d/%b/%Y').date()
+        first_date = datetime.datetime.strptime(config_date, '%Y/%m/%d').date()
     return first_date
 
 first_date = get_first_date()

--- a/ckanext/kpis/templates/ckanext/kpis/index.html
+++ b/ckanext/kpis/templates/ckanext/kpis/index.html
@@ -25,7 +25,7 @@
       <table class="table table-chunky table-bordered table-striped" data-module="plot" data-module-xaxis="{{ h.dump_json(xaxis) }}" data-module-yaxis="{{ h.dump_json(yaxis) }}">
         <thead>
           <tr>
-            <th>{{ _('Week') }}</th>
+            <th>{{ _('Week Starting On') }}</th>
             <th>{{ _('Total Datasets') }}</th>
             <th>{{ _('Percentage Completed') }}</th>
           </tr>
@@ -79,7 +79,7 @@
       <table class="table table-chunky table-bordered table-striped" data-module="plot" data-module-xaxis="{{ h.dump_json(xaxis) }}" data-module-yaxis="{{ h.dump_json(yaxis) }}">
         <thead>
           <tr>
-            <th>{{ _('Week') }}</th>
+            <th>{{ _('Week Starting On') }}</th>
             <th>{{ _('Total Sources') }}</th>
             <th>{{ _('Percentage Completed') }}</th>
           </tr>


### PR DESCRIPTION
If no starting date is configured, then the default starting date is the first revision date. This ensures that the counts begin before any datasets have been added or removed from the portal. Under the old logic, the default starting date was not calculated correctly and it was possible for the starting date to be after the first datasets were added. In such cases, the first dataset counts could be incorrect or even negative if datasets were deleted, since the addition of one or more datasets wouldn't be counted (since they occurred before the count began), but their deletions later on would be.